### PR TITLE
Start parsing EmfPlusPen, EmfPlusBrush, and EmfPlusDrawlines

### DIFF
--- a/src/AutoGenerated/AutoGeneratedConstants.cs
+++ b/src/AutoGenerated/AutoGeneratedConstants.cs
@@ -20,22 +20,22 @@ namespace WInterop
             /// <summary>
             /// Current month 1..12
             /// </summary>
-            public const int CurrentMonth = 10;
+            public const int CurrentMonth = 12;
 
             /// <summary>
             /// Current day of the month 1..31
             /// </summary>
-            public const int CurrentDayOfMonth = 30;
+            public const int CurrentDayOfMonth = 23;
 
             /// <summary>
             /// Current hour from 0..23
             /// </summary>
-            public const int CurrentHour = 16;
+            public const int CurrentHour = 20;
 
             /// <summary>
             /// Current hour from 0..59
             /// </summary>
-            public const int CurrentMinute = 7;
+            public const int CurrentMinute = 22;
         }
 
         public static class Strings
@@ -48,42 +48,42 @@ namespace WInterop
             /// <summary>
             /// Current month 1..12
             /// </summary>
-            public const string CurrentMonth = "10";
+            public const string CurrentMonth = "12";
 
             /// <summary>
             /// Current month 01..12
             /// </summary>
-            public const string CurrentTwoDigitMonth = "10";
+            public const string CurrentTwoDigitMonth = "12";
 
             /// <summary>
             /// Current day of the month 1..31
             /// </summary>
-            public const string CurrentDayOfMonth = "30";
+            public const string CurrentDayOfMonth = "23";
 
             /// <summary>
             /// Current two digit day of the month 01..31
             /// </summary>
-            public const string CurrentTwoDigitDayOfMonth = "30";
+            public const string CurrentTwoDigitDayOfMonth = "23";
 
             /// <summary>
             /// Current hour from 0..23
             /// </summary>
-            public const string CurrentHour = "16";
+            public const string CurrentHour = "20";
 
             /// <summary>
             /// Current two digit hour from 00..23
             /// </summary>
-            public const string CurrentTwoDigitHour = "16";
+            public const string CurrentTwoDigitHour = "20";
 
             /// <summary>
             /// Current hour from 0..59
             /// </summary>
-            public const string CurrentMinute = "7";
+            public const string CurrentMinute = "22";
 
             /// <summary>
             /// Current two digit hour from 00..59
             /// </summary>
-            public const string CurrentTwoDigitMinute = "07";
+            public const string CurrentTwoDigitMinute = "22";
         }
     }
 }

--- a/src/WInterop.GdiPlus/EmfPlus/MetafilePlusBrush.cs
+++ b/src/WInterop.GdiPlus/EmfPlus/MetafilePlusBrush.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Runtime.InteropServices;
+
+namespace WInterop.GdiPlus.EmfPlus
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly ref struct MetafilePlusBrush
+    {
+        private readonly byte _data;
+
+        public unsafe readonly MetafilePlusGraphicsVersion* Version
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return (MetafilePlusGraphicsVersion*)b;
+                }
+            }
+        }
+
+        public unsafe readonly BrushType Type
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(BrushType*)(b + 4);
+                }
+            }
+        }
+
+        public unsafe readonly MetafilePlusSolidBrushData* BrushData
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return (MetafilePlusSolidBrushData*)(b + 8);
+                }
+            }
+        }
+
+        // TODO: Implement BrushData
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly ref struct MetafilePlusSolidBrushData
+    {
+        private readonly byte _data;
+
+        public unsafe readonly MetafilePlusARGB SolidColor
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(MetafilePlusARGB*)(b);
+                }
+            }
+        }
+    }
+
+    public enum BrushType : uint
+    {
+        BrushTypeSolidColor = 0x00000000,
+        BrushTypeHatchFill = 0x00000001,
+        BrushTypeTextureFill = 0x00000002,
+        BrushTypePathGradient = 0x00000003,
+        BrushTypeLinearGradient = 0x00000004
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly ref struct MetafilePlusARGB
+    {
+        public readonly byte Blue;
+        public readonly byte Green;
+        public readonly byte Red;
+        public readonly byte Alpha;
+    }
+}

--- a/src/WInterop.GdiPlus/EmfPlus/MetafilePlusDrawLines.cs
+++ b/src/WInterop.GdiPlus/EmfPlus/MetafilePlusDrawLines.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace WInterop.GdiPlus.EmfPlus
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly ref struct MetafilePlusDrawLines
+    {
+        public const ushort CompressedDataFlag          = 0b0100_0000_0000_0000;
+        public const ushort ExtraLineFlag               = 0b0010_0000_0000_0000;
+        public const ushort RelativeLocationFlag        = 0b0001_0000_0000_0000;
+        public const ushort ObjectIdMask                = 0b0000_0000_1111_1111;
+
+        public readonly MetafilePlusRecord Record;
+
+        private readonly byte _data;
+
+        public unsafe uint Count
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(uint*)b;
+                }
+            }
+        }
+
+        public uint Size
+        {
+            get
+            {
+                if (RelativeLocation)
+                {
+                    return (Count * 0x00000002) + 0x00000010;
+                }
+                else if (CompressedData)
+                {
+                    return (Count * 0x00000004) + 0x00000010;
+                }
+                else
+                {
+                    return (Count * 0x00000008) + 0x00000010;
+                }
+            }
+        }
+
+
+        public uint DataSize
+        {
+            get
+            {
+                if (RelativeLocation)
+                {
+                    return (Count * 0x00000002) + 0x00000004;
+                }
+                else if (CompressedData)
+                {
+                    return (Count * 0x00000004) + 0x00000004;
+                }
+                else
+                {
+                    return (Count * 0x00000008) + 0x00000004;
+                }
+            }
+        }
+
+        public unsafe byte[] PointData
+        {
+            get
+            {
+                byte[] pointData = new byte[DataSize - 4];
+                fixed (byte* ptr = &_data)
+                {
+                    for (int i = 0; 4 + i < DataSize; i++)
+                    {
+                        pointData[i] = ptr[4 + i];
+                    }
+                }
+
+                return pointData;
+            }
+        }
+
+        public bool CompressedData => (Record.Flags & CompressedDataFlag) != 0;
+        public bool ExtraLine => (Record.Flags & ExtraLineFlag) != 0;
+        public bool RelativeLocation => (Record.Flags & RelativeLocationFlag) != 0;
+        public int ObjectId => Record.Flags & ObjectIdMask;
+
+        public MetafilePlusPoint GetPoint(int index)
+        {
+            int offset = index * 4;
+            MetafilePlusPoint point = new ();
+            point.X = BitConverter.ToUInt16(PointData, offset);
+            point.Y = BitConverter.ToUInt16(PointData, offset + 2);
+            return point;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MetafilePlusPointR
+    {
+
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MetafilePlusPoint
+    {
+        public ushort X;
+        public ushort Y;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MetafilePlusPointF
+    {
+        public uint X;
+        public uint Y;
+    }
+}

--- a/src/WInterop.GdiPlus/EmfPlus/MetafilePlusGraphicsVersion.cs
+++ b/src/WInterop.GdiPlus/EmfPlus/MetafilePlusGraphicsVersion.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace WInterop.GdiPlus.EmfPlus
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly ref struct MetafilePlusGraphicsVersion
+    {
+        public const uint MetafileSignatureMask     = 0b1111_1111_1111_1111_1111_0000_0000_0000;
+        public const uint GraphicsVersionMask       = 0b0000_0000_0000_0000_0000_1111_1111_1111;
+
+        private readonly byte _data;
+
+        public unsafe readonly uint MetafileSignature
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return (*(uint*)(b) & MetafileSignatureMask) >> 12;
+                }
+            }
+        }
+
+        public readonly GraphicsVersionEnum GraphicsVersion => (GraphicsVersionEnum)(_data & GraphicsVersionMask);
+    }
+
+    public enum GraphicsVersionEnum : uint
+    {
+        GraphicsVersion1 = 0x0001,
+        GraphicsVersion1_1 = 0x0002
+    }
+}

--- a/src/WInterop.GdiPlus/EmfPlus/MetafilePlusObject.cs
+++ b/src/WInterop.GdiPlus/EmfPlus/MetafilePlusObject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Jeremy W. Kuhne. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace WInterop.GdiPlus.EmfPlus
@@ -29,6 +30,17 @@ namespace WInterop.GdiPlus.EmfPlus
                 fixed (byte* b = &_data)
                 {
                     return *(uint*)b;
+                }
+            }
+        }
+
+        public unsafe byte* ObjectData
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return b;
                 }
             }
         }

--- a/src/WInterop.GdiPlus/EmfPlus/MetafilePlusPen.cs
+++ b/src/WInterop.GdiPlus/EmfPlus/MetafilePlusPen.cs
@@ -1,0 +1,673 @@
+﻿// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Runtime.InteropServices;
+
+namespace WInterop.GdiPlus.EmfPlus
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly ref struct MetafilePlusPen
+    {
+        private readonly byte _data;
+
+        public unsafe readonly MetafilePlusGraphicsVersion* Version
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return (MetafilePlusGraphicsVersion*)b;
+                }
+            }
+        }
+
+        public unsafe readonly uint Type
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(uint*)(b + 4);
+                }
+            }
+        }
+
+        public unsafe MetafilePlusPenData* PenData
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return (MetafilePlusPenData*)(b + 8);
+                }
+            }
+        }
+
+        public unsafe MetafilePlusBrush* BrushObject
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return (MetafilePlusBrush*)(b + GetBrushObjectOffset((MetafilePlusPen*)b));
+                }
+            }
+        }
+
+        public static unsafe int GetBrushObjectOffset(MetafilePlusPen* pen)
+        {
+            int offset = 20; // MetafilePlusObject header + MetafilePlusPen header ?
+            MetafilePlusPenData* penData = (MetafilePlusPenData*)pen->PenData;
+
+            if ((penData->PenDataFlags & PenDataFlags.PenDataTransform) != 0)
+                offset += sizeof(MetafilePlusTransformMatrix);
+
+            if ((penData->PenDataFlags & PenDataFlags.PenDataStartCap) != 0)
+                offset += sizeof(uint);
+
+            if ((penData->PenDataFlags & PenDataFlags.PenDataEndCap) != 0)
+                offset += sizeof(uint);
+
+            if ((penData->PenDataFlags & PenDataFlags.PenDataJoin) != 0)
+                offset += sizeof(uint);
+
+            if ((penData->PenDataFlags & PenDataFlags.PenDataMiterLimit) != 0)
+                offset += sizeof(float);
+
+            if ((penData->PenDataFlags & PenDataFlags.PenDataLineStyle) != 0)
+                offset += sizeof(uint);
+
+            if ((penData->PenDataFlags & PenDataFlags.PenDataDashedLineCap) != 0)
+                offset += sizeof(uint);
+
+            if ((penData->PenDataFlags & PenDataFlags.PenDataDashedLineOffset) != 0)
+                offset += sizeof(uint);
+
+            if ((penData->PenDataFlags & PenDataFlags.PenDataDashedLine) != 0)
+            {
+                MetafilePlusDashedLineData* dashedLine = (MetafilePlusDashedLineData*)((byte*)pen + offset);
+
+                offset += 4; // DashedLineData offset
+                offset += (int)dashedLine->DashedLineDataSize * sizeof(float);
+            }
+
+            if ((penData->PenDataFlags & PenDataFlags.PenDataNonCenter) != 0)
+                offset += sizeof(uint);
+
+            if((penData->PenDataFlags & PenDataFlags.PenDataCompoundLine) != 0)
+            {
+                MetafilePlusCompoundLineData* compoundLine = (MetafilePlusCompoundLineData*)((byte*)pen + offset);
+
+                offset += 4; // CompoundLineData offset
+                offset += (int)compoundLine->CompoundLineDataSize * sizeof(float);
+            }
+
+            if ((penData->PenDataFlags & PenDataFlags.PenDataCustomStartCap) != 0)
+            {
+                MetafilePlusCustomStartCapData* startCap = (MetafilePlusCustomStartCapData*)((byte*)pen + offset);
+
+                offset += 4; // CustomLineCap offset
+                offset += (int)startCap->CustomStartCapSize;
+            }
+
+            if ((penData->PenDataFlags & PenDataFlags.PenDataCustomEndCap) != 0)
+            {
+                MetafilePlusCustomEndCapData* startCap = (MetafilePlusCustomEndCapData*)((byte*)pen + offset);
+
+                offset += 4; // CustomLineCap offset
+                offset += (int)startCap->CustomEndCapSize;
+            }
+
+            return offset;
+        }
+
+        public static unsafe MetafilePlusPen* GetFromMetafilePlusObject(MetafilePlusObject* emfPlusObject)
+        {
+            return (MetafilePlusPen*)((byte*)emfPlusObject + (emfPlusObject->Record.Size - emfPlusObject->DataSize));   
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly ref struct MetafilePlusPenData
+    {
+        private readonly byte _data;
+
+        public unsafe readonly PenDataFlags PenDataFlags
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(PenDataFlags*)b;
+                }
+            }
+        }
+
+        public unsafe readonly UnitType PenUnit
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(UnitType*)(b + 4);
+                }
+            }
+        }
+
+        public unsafe readonly float PenWidth
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(float*)(b + 8);
+                }
+            }
+        }
+
+        public unsafe MetafilePlusPenOptionalData* OptionalData
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return (MetafilePlusPenOptionalData*)b;
+                }
+            }
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly ref struct MetafilePlusPenOptionalData
+    {
+        private readonly PenDataFlags _penDataFlags;
+        private readonly byte _data;
+
+        // TODO: Refactor this.
+        private unsafe int GetOptionalDataOffset(PenDataFlags flag)
+        {
+            int offset = 8;
+
+            if((_penDataFlags & flag) != 0)
+            {
+                if ((_penDataFlags & PenDataFlags.PenDataTransform) != 0)
+                    offset += sizeof(MetafilePlusTransformMatrix);
+
+                if (flag == PenDataFlags.PenDataStartCap)
+                    return offset;
+
+                if ((_penDataFlags & PenDataFlags.PenDataStartCap) != 0)
+                    offset += sizeof(uint);
+
+                if (flag == PenDataFlags.PenDataEndCap)
+                    return offset;
+
+                if ((_penDataFlags & PenDataFlags.PenDataEndCap) != 0)
+                    offset += sizeof(uint);
+
+                if (flag == PenDataFlags.PenDataJoin)
+                    return offset;
+
+                if ((_penDataFlags & PenDataFlags.PenDataJoin) != 0)
+                    offset += sizeof(uint);
+
+                if (flag == PenDataFlags.PenDataMiterLimit)
+                    return offset;
+
+                if ((_penDataFlags & PenDataFlags.PenDataMiterLimit) != 0)
+                    offset += sizeof(float);
+
+                if (flag == PenDataFlags.PenDataLineStyle)
+                    return offset;
+
+                if ((_penDataFlags & PenDataFlags.PenDataLineStyle) != 0)
+                    offset += sizeof(uint);
+
+                if (flag == PenDataFlags.PenDataDashedLineCap)
+                    return offset;
+
+                if ((_penDataFlags & PenDataFlags.PenDataDashedLineCap) != 0)
+                    offset += sizeof(uint);
+
+                if (flag == PenDataFlags.PenDataDashedLineOffset)
+                    return offset;
+
+                if ((_penDataFlags & PenDataFlags.PenDataDashedLineOffset) != 0)
+                    offset += sizeof(uint);
+
+                if (flag == PenDataFlags.PenDataDashedLine)
+                    return offset;
+
+                if ((_penDataFlags & PenDataFlags.PenDataDashedLine) != 0)
+                {
+                    MetafilePlusDashedLineData* dashedLine = (MetafilePlusDashedLineData*)((byte*)_data + offset);
+
+                    offset += 4; // DashedLineData offset
+                    offset += (int)dashedLine->DashedLineDataSize * sizeof(float);
+                }
+
+                if (flag == PenDataFlags.PenDataNonCenter)
+                    return offset;
+
+                if ((_penDataFlags & PenDataFlags.PenDataNonCenter) != 0)
+                    offset += sizeof(uint);
+
+                if (flag == PenDataFlags.PenDataCompoundLine)
+                    return offset;
+
+                if ((_penDataFlags & PenDataFlags.PenDataCompoundLine) != 0)
+                {
+                    MetafilePlusCompoundLineData* compoundLine = (MetafilePlusCompoundLineData*)((byte*)_data + offset);
+
+                    offset += 4; // CompoundLineData offset
+                    offset += (int)compoundLine->CompoundLineDataSize * sizeof(float);
+                }
+
+                if (flag == PenDataFlags.PenDataCustomStartCap)
+                    return offset;
+
+                if ((_penDataFlags & PenDataFlags.PenDataCustomStartCap) != 0)
+                {
+                    MetafilePlusCustomStartCapData* startCap = (MetafilePlusCustomStartCapData*)((byte*)_data + offset);
+
+                    offset += 4; // CustomLineCap offset
+                    offset += (int)startCap->CustomStartCapSize;
+                }
+
+                if (flag == PenDataFlags.PenDataCustomEndCap)
+                    return offset;
+
+                if ((_penDataFlags & PenDataFlags.PenDataCustomEndCap) != 0)
+                {
+                    MetafilePlusCustomEndCapData* startCap = (MetafilePlusCustomEndCapData*)((byte*)_data + offset);
+
+                    offset += 4; // CustomLineCap offset
+                    offset += (int)startCap->CustomEndCapSize;
+                }
+            }
+
+            return offset;
+        }
+
+        public unsafe MetafilePlusTransformMatrix* TransformMatrix
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return (MetafilePlusTransformMatrix*)b;
+                }
+            }
+        }
+
+        public unsafe LineCapType StartCap
+        {
+            get
+            {
+                int offset = GetOptionalDataOffset(PenDataFlags.PenDataStartCap);
+                fixed (byte* b = &_data)
+                {
+                    return *(LineCapType*)(b + offset);
+                }
+            }
+        }
+
+        public unsafe LineCapType EndCap
+        {
+            get
+            {
+                int offset = GetOptionalDataOffset(PenDataFlags.PenDataEndCap);
+                fixed (byte* b = &_data)
+                {
+                    return *(LineCapType*)(b + offset);
+                }
+            }
+        }
+
+        public unsafe LineJoinType Join
+        {
+            get
+            {
+                int offset = GetOptionalDataOffset(PenDataFlags.PenDataJoin);
+                fixed (byte* b = &_data)
+                {
+                    return *(LineJoinType*)(b + offset);
+                }
+            }
+        }
+
+        public unsafe float MiterLimit
+        {
+            get
+            {
+                int offset = GetOptionalDataOffset(PenDataFlags.PenDataMiterLimit);
+                fixed (byte* b = &_data)
+                {
+                    return *(float*)(b + offset);
+                }
+            }
+        }
+
+        public unsafe LineStyle LineStyle
+        {
+            get
+            {
+                int offset = GetOptionalDataOffset(PenDataFlags.PenDataLineStyle);
+                fixed (byte* b = &_data)
+                {
+                    return *(LineStyle*)(b + offset);
+                }
+            }
+        }
+
+        public unsafe DashedLineCapType DashedLineCapType
+        {
+            get
+            {
+                int offset = GetOptionalDataOffset(PenDataFlags.PenDataDashedLineCap);
+                fixed (byte* b = &_data)
+                {
+                    return *(DashedLineCapType*)(b + offset);
+                }
+            }
+        }
+
+        public unsafe float DashOffset
+        {
+            get
+            {
+                int offset = GetOptionalDataOffset(PenDataFlags.PenDataDashedLineOffset);
+                fixed (byte* b = &_data)
+                {
+                    return *(float*)(b + offset);
+                }
+            }
+        }
+
+        public unsafe MetafilePlusDashedLineData* DashedLineData
+        {
+            get
+            {
+                int offset = GetOptionalDataOffset(PenDataFlags.PenDataDashedLine);
+                fixed (byte* b = &_data)
+                {
+                    return (MetafilePlusDashedLineData*)(b + offset);
+                }
+            }
+        }
+
+        public unsafe PenAlignment PenAlignment
+        {
+            get
+            {
+                int offset = GetOptionalDataOffset(PenDataFlags.PenDataNonCenter);
+                fixed (byte* b = &_data)
+                {
+                    return *(PenAlignment*)(b + offset);
+                }
+            }
+        }
+
+        public unsafe MetafilePlusCompoundLineData* CompoundLineData
+        {
+            get
+            {
+                int offset = GetOptionalDataOffset(PenDataFlags.PenDataCompoundLine);
+                fixed (byte* b = &_data)
+                {
+                    return (MetafilePlusCompoundLineData*)b;
+                }
+            }
+        }
+
+        public unsafe MetafilePlusCustomStartCapData* CustomStartCapData
+        {
+            get
+            {
+                int offset = GetOptionalDataOffset(PenDataFlags.PenDataCustomStartCap);
+                fixed (byte* b = &_data)
+                {
+                    return (MetafilePlusCustomStartCapData*)(b + offset);
+                }
+            }
+        }
+
+        public unsafe MetafilePlusCustomEndCapData* CustomEndCapData
+        {
+            get
+            {
+                int offset = GetOptionalDataOffset(PenDataFlags.PenDataCustomEndCap);
+                fixed (byte* b = &_data)
+                {
+                    return (MetafilePlusCustomEndCapData*)(b + offset);
+                }
+            }
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly ref struct MetafilePlusTransformMatrix
+    {
+        private readonly byte _data;
+
+        // TODO: Implement EmfPlusTransformMatrix
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly ref struct MetafilePlusDashedLineData
+    {
+        private readonly byte _data;
+
+        public unsafe readonly uint DashedLineDataSize
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(uint*)b;
+                }
+            }
+        }
+
+        public unsafe readonly float DashedLineData
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(float*)(b + 4);
+                }
+            }
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly ref struct MetafilePlusCompoundLineData
+    {
+        private readonly byte _data;
+
+        public unsafe readonly uint CompoundLineDataSize
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(uint*)b;
+                }
+            }
+        }
+
+        public unsafe readonly float CompoundLineData
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(float*)(b + 4);
+                }
+            }
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly ref struct MetafilePlusCustomStartCapData
+    {
+        private readonly byte _data;
+
+        public unsafe readonly uint CustomStartCapSize
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(uint*)b;
+                }
+            }
+        }
+
+        public unsafe readonly MetafilePlusCustomLineCap CustomStartCap
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(MetafilePlusCustomLineCap*)(b + 4);
+                }
+            }
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly ref struct MetafilePlusCustomEndCapData
+    {
+        private readonly byte _data;
+
+        public unsafe readonly uint CustomEndCapSize
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(uint*)b;
+                }
+            }
+        }
+
+        public unsafe readonly MetafilePlusCustomLineCap CustomEndCap
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(MetafilePlusCustomLineCap*)(b + 4);
+                }
+            }
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly ref struct MetafilePlusCustomLineCap
+    {
+        private readonly byte _data;
+
+        public unsafe readonly MetafilePlusGraphicsVersion* Version
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return (MetafilePlusGraphicsVersion*)b;
+                }
+            }
+        }
+
+        public unsafe readonly uint Type
+        {
+            get
+            {
+                fixed (byte* b = &_data)
+                {
+                    return *(uint*)(b + 4);
+                }
+            }
+        }
+
+        // TODO: Implement CustomLineCapData
+    }
+
+    public enum PenDataFlags : uint
+    {
+        PenDataTransform = 0x0001,
+        PenDataStartCap = 0x0002,
+        PenDataEndCap = 0x0004,
+        PenDataJoin = 0x0008,
+        PenDataMiterLimit = 0x0010,
+        PenDataLineStyle = 0x0020,
+        PenDataDashedLineCap = 0x0040,
+        PenDataDashedLineOffset = 0x0080,
+        PenDataDashedLine = 0x0100,
+        PenDataNonCenter = 0x0200,
+        PenDataCompoundLine = 0x0400,
+        PenDataCustomStartCap = 0x0800,
+        PenDataCustomEndCap = 0x1000
+    };
+
+    public enum UnitType : uint
+    {
+        UnitTypeWorld = 0x00,
+        UnitTypeDisplay = 0x01,
+        UnitTypePixel = 0x02,
+        UnitTypePoint = 0x03,
+        UnitTypeInch = 0x04,
+        UnitTypeDocument = 0x05,
+        UnitTypeMillimeter = 0x06
+    }
+
+    public enum LineCapType : int
+    {
+        LineCapTypeFlat = 0x00000000,
+        LineCapTypeSquare = 0x00000001,
+        LineCapTypeRound = 0x00000002,
+        LineCapTypeTriangle = 0x00000003,
+        LineCapTypeNoAnchor = 0x00000010,
+        LineCapTypeSquareAnchor = 0x00000011,
+        LineCapTypeRoundAnchor = 0x00000012,
+        LineCapTypeDiamondAnchor = 0x00000013,
+        LineCapTypeArrowAnchor = 0x00000014,
+        LineCapTypeAnchorMask = 0x000000F0,
+        LineCapTypeCustom = 0x000000FF
+    }
+
+    public enum LineJoinType : int
+    {
+        LineJoinTypeMiter = 0x00000000,
+        LineJoinTypeBevel = 0x00000001,
+        LineJoinTypeRound = 0x00000002,
+        LineJoinTypeMiterClipped = 0x00000003
+    }
+
+    public enum LineStyle : int
+    {
+        LineStyleSolid = 0x00000000,
+        LineStyleDash = 0x00000001,
+        LineStyleDot = 0x00000002,
+        LineStyleDashDot = 0x00000003,
+        LineStyleDashDotDot = 0x00000004,
+        LineStyleCustom = 0x00000005
+    }
+
+    public enum DashedLineCapType : int
+    {
+        DashedLineCapTypeFlat = 0x00000000,
+        DashedLineCapTypeRound = 0x00000002,
+        DashedLineCapTypeTriangle = 0x00000003
+    }
+
+    public enum PenAlignment : int
+    {
+        PenAlignmentCenter = 0x00000000,
+        PenAlignmentInset = 0x00000001,
+        PenAlignmentLeft = 0x00000002,
+        PenAlignmentOutset = 0x00000003,
+        PenAlignmentRight = 0x00000004
+    }
+}

--- a/src/WInterop.GdiPlus/EmfPlus/MetafilePlusRecord.cs
+++ b/src/WInterop.GdiPlus/EmfPlus/MetafilePlusRecord.cs
@@ -54,5 +54,10 @@ namespace WInterop.GdiPlus.EmfPlus
 
             return (MetafilePlusRecord*)(&comment->Data + sizeof(uint));
         }
+
+        public static unsafe MetafilePlusRecord* GetNextMetafilePlusRecord(MetafilePlusRecord* record)
+        {
+            return (MetafilePlusRecord*)((byte*)record + record->Size);
+        }
     }
 }

--- a/src/WInterop.GdiPlus/GpLineCapType.cs
+++ b/src/WInterop.GdiPlus/GpLineCapType.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WInterop.GdiPlus
+{
+    public enum GpLineCapType
+    {
+        LineCapFlat = 0,
+        LineCapSquare = 1,
+        LineCapRound = 2,
+        LineCapTriangle = 3,
+        LineCapNoAnchor = 0x10,
+        LineCapSquareAnchor = 0x11,
+        LineCapRoundAnchor = 0x12,
+        LineCapDiamondAnchor = 0x13,
+        LineCapArrowAnchor = 0x14,
+        LineCapCustom = 0xff
+    }
+}

--- a/src/WInterop.GdiPlus/Native/GdiPlusImports.cs
+++ b/src/WInterop.GdiPlus/Native/GdiPlusImports.cs
@@ -83,6 +83,18 @@ namespace WInterop.GdiPlus.Native
             GpPen pen,
             ARGB* argb);
 
+        [SuppressGCTransition]
+        [DllImport(Libraries.GdiPlus, SetLastError = true, ExactSpelling = true)]
+        public static extern unsafe GpStatus GdipSetPenStartCap(
+            GpPen pen,
+            GpLineCapType startCap);
+
+        [SuppressGCTransition]
+        [DllImport(Libraries.GdiPlus, SetLastError = true, ExactSpelling = true)]
+        public static extern unsafe GpStatus GdipSetPenEndCap(
+            GpPen pen,
+            GpLineCapType endCap);
+
         [DllImport(Libraries.GdiPlus, SetLastError = true, ExactSpelling = true)]
         public static extern GpStatus GdipDeletePen(
             GpPen pen);

--- a/src/WInterop.GdiPlus/Pen.cs
+++ b/src/WInterop.GdiPlus/Pen.cs
@@ -27,6 +27,16 @@ namespace WInterop.GdiPlus
             _gpPen = gpPen;
         }
 
+        public void SetStartCap(GpLineCapType lineCap)
+        {
+            GdiPlusImports.GdipSetPenStartCap(_gpPen, lineCap).ThrowIfFailed();
+        }
+
+        public void SetEndCap(GpLineCapType lineCap)
+        {
+            GdiPlusImports.GdipSetPenEndCap(_gpPen, lineCap).ThrowIfFailed();
+        }
+
         public unsafe ARGB Color
         {
             get


### PR DESCRIPTION
This is in regards to https://github.com/dotnet/winforms/issues/4341

I've started enumerating and parsing the GDI+ records using the EMF+ specification and would greatly appreciate your feedback when you have a moment. Specifically I'm looking for some feedback on how I'm walking the byte pointer and casting to the structures, and whether or not there is a better way to do this. I haven't used pointers in this fashion before and feel like there is room for improvement here.

In the meantime, I'll start looking at enumerating and parsing the same data via the [equivalent callback](https://github.com/JeremyKuhne/WInterop/blob/main/src/Tests/WInterop.Tests/GdiPlus/Metafiles.cs#L90).